### PR TITLE
Increase picofuzz-conformance memory limit

### DIFF
--- a/tests/picofuzz/common.ts
+++ b/tests/picofuzz/common.ts
@@ -12,11 +12,13 @@ export function runPicofuzzTest(
     repeat = 10,
     noLogs = false,
     ignore = [],
+    highMemory = false,
   }: {
     initGenesisFromAncestry?: boolean;
     repeat?: number;
     noLogs?: boolean;
     ignore?: string[];
+    highMemory?: boolean;
   } = {},
 ) {
   describe(`[picofuzz] ${name}`, { timeout }, () => {
@@ -50,6 +52,7 @@ export function runPicofuzzTest(
         dockerArgs: noLogs ? ["-e", "JAM_LOG=info"] : [],
         options: {
           initGenesisFromAncestry,
+          highMemory,
         },
       });
       picofuzzProc = await picofuzz({

--- a/tests/picofuzz/conformance.test.ts
+++ b/tests/picofuzz/conformance.test.ts
@@ -8,4 +8,5 @@ runPicofuzzTest("conformance", EXAMPLES_DIR, {
   repeat: 1,
   noLogs: true,
   ignore: [],
+  highMemory: true,
 });


### PR DESCRIPTION
## Summary
- Enable `highMemory` (2048m) for the picofuzz-conformance typeberry container to fix OOM issues during test runs

## Test plan
- [ ] Verify picofuzz-conformance CI job completes without OOM errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)