### PR TITLE
chore: bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/deploy-perf-graph.yml
+++ b/.github/workflows/deploy-perf-graph.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./perf-graph
 
       - name: Download picofuzz CSV artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: picofuzz-csv-*
           path: ./perf-graph/csv-artifacts
@@ -74,13 +74,13 @@ jobs:
         working-directory: ./perf-graph
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./perf-graph/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/picofuzz.yml
+++ b/.github/workflows/picofuzz.yml
@@ -86,7 +86,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
       - run: mkdir ./picofuzz-result && chmod 777 ./picofuzz-result
       - name: Download previous CSV files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: picofuzz-csv-${{ matrix.test }}
           path: ./picofuzz-result/
@@ -99,7 +99,7 @@ jobs:
           npm exec tsx --test tests/picofuzz/${{ matrix.test }}.test.ts
 
       - name: Upload CSV results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: picofuzz-csv-${{ matrix.test }}
           path: ./picofuzz-result/${{ matrix.test }}.csv

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -108,7 +108,7 @@ jobs:
           echo "workflow_run_id=$WORKFLOW_RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download docker image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: typeberry-docker-image
           path: ./docker-image
@@ -152,14 +152,14 @@ jobs:
         run: npm start -w picofuzz-benchmark
 
       - name: Upload benchmark report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-report
           path: ./benchmark-report.md
         if: always()
 
       - name: Upload CSV results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: picofuzz-results
           path: ./picofuzz-result/*.csv
@@ -175,7 +175,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -183,12 +183,12 @@ jobs:
           repositories: typeberry
 
       - name: Download benchmark report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: benchmark-report
 
       - name: Post or update comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -177,7 +177,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: fluffylabs
           repositories: typeberry

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -48,7 +48,7 @@ jobs:
           git add README.md
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: update submodules'

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Bump outdated GitHub Actions to their latest major tags. `actions/checkout@v6` and `actions/setup-node@v6` were already on latest and left as-is.

**Bumps:**
- `actions/download-artifact`: v4 → v8 (`picofuzz.yml`, `pr-benchmark.yml`, `deploy-perf-graph.yml`)
- `actions/upload-artifact`: v4 → v7 (`picofuzz.yml`, `pr-benchmark.yml`)
- `actions/github-script`: v7 → v9 (`pr-benchmark.yml`)
- `actions/create-github-app-token`: v2 → v3 (`pr-benchmark.yml`, `update-submodules.yml`)
- `actions/configure-pages`: v5 → v6 (`deploy-perf-graph.yml`)
- `actions/upload-pages-artifact`: v4 → v5 (`deploy-perf-graph.yml`)
- `actions/deploy-pages`: v4 → v5 (`deploy-perf-graph.yml`)
- `peter-evans/create-pull-request`: v7 → v8 (`update-submodules.yml`)

## Test plan
- [ ] CI runs green on this PR (workflows that fire on PRs)
- [ ] Manually trigger `pr-benchmark.yml` via `workflow_dispatch` to verify the large `upload-artifact` / `download-artifact` / `github-script` bumps
- [ ] Next scheduled run of `picofuzz.yml` uploads CSVs successfully
- [ ] Next scheduled run of `update-submodules.yml` opens a PR
- [ ] `deploy-perf-graph.yml` deploys after a successful Picofuzz run

🤖 Generated with [Claude Code](https://claude.com/claude-code)