### PR TITLE
Fix flaky Docker conformance & test-vectors (shared image tag race)

### DIFF
--- a/.github/actions/provision-typeberry/action.yml
+++ b/.github/actions/provision-typeberry/action.yml
@@ -1,5 +1,5 @@
 name: Provision Typeberry image
-description: Fetch or build the typeberry image for a version and tag it `typeberry:test`.
+description: Fetch or build the typeberry image for a version and tag it `typeberry:test` (docker/npm) or `typeberry:source` (source).
 inputs:
   target:
     description: 'docker | npm | source'

--- a/.github/actions/provision-typeberry/provision.sh
+++ b/.github/actions/provision-typeberry/provision.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Provision the typeberry image under test as `typeberry:test`.
+# Provision the typeberry image under test: `typeberry:test` for the docker/npm
+# targets, `typeberry:source` for the source target (see the IMAGE note below).
 #
 # Inputs (env):
 #   TARGET   docker | npm | source
@@ -14,8 +15,22 @@ set -euo pipefail
 TARGET="${TARGET:?set TARGET to docker|npm|source}"
 VERSION="${VERSION:-next}"
 ROOT="${GITHUB_WORKSPACE:-$PWD}"
-IMAGE="typeberry:test"
 REPO_URL="https://github.com/FluffyLabs/typeberry"
+
+# Image tag the test suites consume. The docker and npm targets are
+# interchangeable in shape (a global `jam` bin, published-artifact layout), so
+# they share the `typeberry:test` tag. The source target is NOT: it ships the
+# `@typeberry/test-runner` workspace under /app (with package.json), which the
+# conformance / test-vectors suites invoke. It must live under its own tag so the
+# docker/npm workflows — which run on the same cron and share the self-hosted
+# runner's docker daemon — cannot overwrite `typeberry:test` out from under those
+# suites mid-run (that race surfaced as `/app/package.json ENOENT` and
+# `No workspaces found: --workspace=@typeberry/test-runner`).
+if [ "$TARGET" = "source" ]; then
+  IMAGE="typeberry:source"
+else
+  IMAGE="typeberry:test"
+fi
 
 if [ "$VERSION" = "next" ]; then
   DOCKER_TAG="next"; NPM_VERSION="next"; SRC_REF="main"

--- a/.github/workflows/docker-conformance.yml
+++ b/.github/workflows/docker-conformance.yml
@@ -71,5 +71,9 @@ jobs:
         run: npm ci
 
       - name: Run Docker Conformance test
+        env:
+          # Consume the isolated source image (see provision-typeberry/provision.sh);
+          # the shared `typeberry:test` tag is owned by the docker/npm workflows.
+          TYPEBERRY_IMAGE: typeberry:source
         run: |
           npm exec tsx --test tests/docker-conformance.test.ts

--- a/.github/workflows/docker-test-vectors.yml
+++ b/.github/workflows/docker-test-vectors.yml
@@ -71,5 +71,9 @@ jobs:
         run: npm ci
 
       - name: Run Docker Test Vectors test
+        env:
+          # Consume the isolated source image (see provision-typeberry/provision.sh);
+          # the shared `typeberry:test` tag is owned by the docker/npm workflows.
+          TYPEBERRY_IMAGE: typeberry:source
         run: |
           npm exec tsx --test tests/docker-test-vectors.test.ts


### PR DESCRIPTION
## Problem

`Docker Conformance` and `Docker Test Vectors` fail intermittently:
- Conformance → `npm error ENOENT ... open '/app/package.json'`
- Test-vectors → `npm error No workspaces found: --workspace=@typeberry/test-runner`

Runs alternate pass/fail (see workflow history), which pointed at a race rather than a deterministic break.

## Root cause

Every workflow provisions a **single shared, mutable Docker tag `typeberry:test`** on the same self-hosted runner, and they **all fire on the same cron schedule** (6/10/14/18/22 UTC).

The `docker`/`npm` targets tag `typeberry:test` with the published image (a global `jam` bin, no `/app` workspace). The conformance/test-vectors suites need the **`source`** image — the only one shipping the `@typeberry/test-runner` workspace and `/app/package.json` — yet it shared that same tag. When a `docker`/`npm` run overwrote `typeberry:test` between the source suites' `init` job and their test job, those suites ran against the wrong image. That timing dependency is exactly why it was flaky.

## Fix

Isolate the source image under its own tag so the docker/npm workflows can no longer clobber it:

- `provision-typeberry/provision.sh` — the `source` target now tags `typeberry:source`; `docker`/`npm` keep the shared (and mutually compatible) `typeberry:test`.
- `docker-conformance.yml` / `docker-test-vectors.yml` — test step sets `TYPEBERRY_IMAGE: typeberry:source`.
- Updated the now-stale tag descriptions in `provision.sh` and `action.yml`.

The only writers of `typeberry:source` are now the two source suites, which build byte-identical content — so the race is eliminated, not just narrowed.

## Notes / possible follow-ups (not in this PR)

- The `docker` and `npm` targets still share `typeberry:test`, so e.g. `npm-works` can technically run against a docker-published image. Currently harmless because both expose `jam`, which is why it went unnoticed — but true per-target isolation is a reasonable follow-up.
- The `init` job → test job split widens the timing window and only works because all runners share one Docker daemon; collapsing it is another possible cleanup.

## Verification

Can't be reproduced locally (the bug requires the shared-runner race); the fix directly removes the shared-state collision the CI logs proved. Green scheduled runs on these two workflows will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)