### PR TITLE
Reduce scheduled job frequency to relieve the single shared runner

### DIFF
--- a/.github/workflows/docker-conformance.yml
+++ b/.github/workflows/docker-conformance.yml
@@ -13,15 +13,8 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
-    - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 00:00 Europe/Warsaw = 22:00 UTC (UTC+2 summer)
     - cron: '0 22 * * *'
 
 concurrency:

--- a/.github/workflows/docker-imports.yml
+++ b/.github/workflows/docker-imports.yml
@@ -13,16 +13,9 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
-    - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
-    - cron: '0 22 * * *'
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 02:00 Europe/Warsaw = 00:00 UTC (UTC+2 summer)
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/docker-test-vectors.yml
+++ b/.github/workflows/docker-test-vectors.yml
@@ -13,16 +13,9 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
-    - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
-    - cron: '0 22 * * *'
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 01:00 Europe/Warsaw = 23:00 UTC (UTC+2 summer)
+    - cron: '0 23 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/docker-works.yml
+++ b/.github/workflows/docker-works.yml
@@ -13,16 +13,9 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
-    - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
-    - cron: '0 22 * * *'
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 03:00 Europe/Warsaw = 01:00 UTC (UTC+2 summer)
+    - cron: '0 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/minifuzz.yml
+++ b/.github/workflows/minifuzz.yml
@@ -13,16 +13,11 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
-    - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
-    - cron: '0 22 * * *'
+    # 2x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 22:00 Europe/Warsaw = 20:00 UTC (UTC+2 summer)
+    - cron: '0 20 * * *'
+    # 06:00 Europe/Warsaw = 04:00 UTC (UTC+2 summer)
+    - cron: '0 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/npm-imports.yml
+++ b/.github/workflows/npm-imports.yml
@@ -13,11 +13,9 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    - cron: '0 6 * * *'
-    - cron: '0 10 * * *'
-    - cron: '0 14 * * *'
-    - cron: '0 18 * * *'
-    - cron: '0 22 * * *'
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 04:00 Europe/Warsaw = 02:00 UTC (UTC+2 summer)
+    - cron: '0 2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/npm-minifuzz.yml
+++ b/.github/workflows/npm-minifuzz.yml
@@ -13,11 +13,11 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    - cron: '0 6 * * *'
-    - cron: '0 10 * * *'
-    - cron: '0 14 * * *'
-    - cron: '0 18 * * *'
-    - cron: '0 22 * * *'
+    # 2x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 23:00 Europe/Warsaw = 21:00 UTC (UTC+2 summer)
+    - cron: '0 21 * * *'
+    # 07:00 Europe/Warsaw = 05:00 UTC (UTC+2 summer)
+    - cron: '0 5 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/npm-works.yml
+++ b/.github/workflows/npm-works.yml
@@ -13,11 +13,9 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    - cron: '0 6 * * *'
-    - cron: '0 10 * * *'
-    - cron: '0 14 * * *'
-    - cron: '0 18 * * *'
-    - cron: '0 22 * * *'
+    # 1x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 04:30 Europe/Warsaw = 02:30 UTC (UTC+2 summer)
+    - cron: '30 2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/picofuzz.yml
+++ b/.github/workflows/picofuzz.yml
@@ -13,16 +13,11 @@ on:
         default: 'next'
   repository_dispatch:
   schedule:
-    # 8:00 AM Europe/Warsaw (6:00 UTC, using UTC+2 summer time)
-    - cron: '0 6 * * *'
-    # 12:00 PM Europe/Warsaw (10:00 UTC)
-    - cron: '0 10 * * *'
-    # 4:00 PM Europe/Warsaw (14:00 UTC)
-    - cron: '0 14 * * *'
-    # 8:00 PM Europe/Warsaw (18:00 UTC)
+    # 2x/day (reduced from 5x) — staggered overnight to relieve the single shared self-hosted runner.
+    # 20:00 Europe/Warsaw = 18:00 UTC (UTC+2 summer)
     - cron: '0 18 * * *'
-    # Midnight Europe/Warsaw (22:00 UTC previous day)
-    - cron: '0 22 * * *'
+    # 05:00 Europe/Warsaw = 03:00 UTC (UTC+2 summer)
+    - cron: '0 3 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Problem

Every scheduled workflow fired **5×/day** at the same four timestamps (6/10/14/18/22 UTC). With matrices, that funneled **~85 jobs/day** onto the **single** self-hosted runner (`xnote-testing` — carries both `perf` and `non-perf`, runs one job at a time), which *also* serves every push/PR. Demand was ~28 h of work on a 24 h machine, producing a 10+ hour scheduled backlog (jobs from the morning still queued in the evening).

## Change

| Group | Before | After |
|---|---|---|
| Smoke tests (docker works/conformance/imports/test-vectors, npm imports/works) | 5×/day | **1×/day** |
| Fuzz tests (minifuzz, npm-minifuzz, picofuzz) | 5×/day | **2×/day** |

All runs are **staggered across 18:00–05:00 UTC** (overnight Warsaw time) so the batch drains while no one is pushing, leaving the workday clear for PR CI.

New schedule (UTC):

```
picofuzz            18:00, 03:00
minifuzz            20:00, 04:00
npm-minifuzz        21:00, 05:00
docker-conformance  22:00
docker-test-vectors 23:00
docker-imports      00:00
docker-works        01:00
npm-imports         02:00
npm-works           02:30
```

Scheduled load drops from **~85 jobs (~28 h)/day → ~23 jobs (~8 h)/day**. `update-submodules` is unchanged (it runs on GitHub-hosted `ubuntu-latest`, not the bottleneck).

## Note

This relieves the symptom. The root cause is one machine doing perf + non-perf + all PR/push CI; the durable fix is a second runner or splitting `perf`/`non-perf` onto separate executors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)