### PR TITLE
Match renamed importer log line in docker-imports test

### DIFF
--- a/tests/docker-imports.test.ts
+++ b/tests/docker-imports.test.ts
@@ -21,7 +21,12 @@ describe("Docker image can import block dumps", { timeout: TEST_TIMEOUT }, () =>
         `/block-dumps/${dir}.bin`,
       ).terminateAfter(TEST_TIMEOUT);
 
-      await proc.waitForMessage(/Best block: #100/);
+      // typeberry renamed the importer's best-block log from `Best block: #N`
+      // to `🧊 Best: #N`; match both forms so a cosmetic upstream log change
+      // doesn't let the container finish the import, exit 0, and fail the test
+      // with "Exited" (the regex never matching). Asserting #100 still guards
+      // against a short import (e.g. the swallowed-EOF reader bug).
+      await proc.waitForMessage(/Best(?: block)?: #100/);
     });
   });
 });


### PR DESCRIPTION
## Problem

The nightly **NPM Imports Test** fails — every fixture (`fallback`, `safrole`, `storage`, `storage_light`) reports `Exited`, even though the import itself finishes correctly.

[Failing run](https://github.com/FluffyLabs/typeberry-testing/actions/runs/27309626757/job/80676295708)

## Root cause

The container does the work correctly: it reaches the last block (`🧊 Best: #100`), logs `All blocks scheduled to be imported.`, shuts every module down cleanly and exits `0` (`✅ Done.`).

But `tests/docker-imports.test.ts` waited for the literal `Best block: #100`. typeberry renamed that importer log line `Best block: #N` → `🧊 Best: #N`, so the regex never matches. The batch `import` then runs to completion and exits *before* the message is ever seen, and `ExternalProcess.waitForMessage` rejects any exit as `"Exited"` → all four fixtures fail.

It surfaces as a fast `Exited` failure (~29s each) rather than a literal timeout only because `import` is a batch command that exits on its own; a long-running process with the same stale matcher would hang to the 5-min timeout instead. Same root cause either way.

## Fix

Make the matcher tolerant of both log formats:

```js
await proc.waitForMessage(/Best(?: block)?: #100/);
```

The `#100` assertion is kept on purpose — we can't rely on exit-code-0 alone because of the upstream swallowed-EOF reader bug (`import` can exit `0` with the file tail unread), so we still need to confirm block #100 was reached.

## Verification

- Regex checked against the real CI log strings: old regex vs new log = `false`; new regex matches both new and old formats = `true` / `true`.
- `biome ci` clean across the repo.
- Not run end-to-end here — that needs docker + the `next` npm image + block-dumps + ~13 min on the single shared self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
