### PR TITLE
Run picofuzz conformance with an in-memory state db

### DIFF
--- a/tests/common.ts
+++ b/tests/common.ts
@@ -136,10 +136,36 @@ export async function typeberry({
   timeout: number;
   dockerArgs?: string[];
   sharedVolume?: string;
-  options?: { highMemory?: boolean; memory?: string; initGenesisFromAncestry?: boolean; flavor?: "tiny" | "full" };
+  options?: {
+    highMemory?: boolean;
+    memory?: string;
+    initGenesisFromAncestry?: boolean;
+    flavor?: "tiny" | "full";
+    inMemory?: boolean;
+  };
 }) {
   const containerName = uniqueContainerName("typeberry");
   trackedContainers.add(containerName);
+  // Global config directives applied before the `fuzz-target` subcommand, in
+  // order. `--config=default` is the implicit default; we list it explicitly so
+  // jq-style overrides have a base config to layer onto.
+  const configArgs: string[] = [];
+  if (options.flavor === "full" || options.inMemory === true) {
+    configArgs.push("--config=default");
+  }
+  if (options.flavor === "full") {
+    configArgs.push('--config=.flavor="full"');
+  }
+  if (options.inMemory === true) {
+    // Force a pure in-memory state db. The default config sets
+    // `database_base_path: "./database"`, which the fuzz-target inherits and
+    // turns into an on-disk LMDB/fjall store; clearing it makes the node's
+    // resolveFuzzDbBase() return undefined → in-memory backend. Used by the
+    // conformance suite, whose short per-vector genesis resets are slow on the
+    // on-disk fuzz db and don't need its heap-bounding (state roots are
+    // storage-agnostic, so correctness is unaffected).
+    configArgs.push('--config=.database_base_path="undefined"');
+  }
   const typeberry = ExternalProcess.spawn(
     "typeberry",
     "docker",
@@ -154,7 +180,7 @@ export async function typeberry({
     "-v",
     `${sharedVolume}:/shared`,
     TYPEBERRY_IMAGE,
-    ...(options.flavor === "full" ? ["--config=default", '--config=.flavor="full"'] : []),
+    ...configArgs,
     "fuzz-target",
     ...(options.initGenesisFromAncestry === true ? ["--init-genesis-from-ancestry"] : []),
     SOCKET_PATH,

--- a/tests/picofuzz/common.ts
+++ b/tests/picofuzz/common.ts
@@ -13,6 +13,7 @@ export function runPicofuzzTest(
     highMemory = false,
     flavour = "tiny",
     memory,
+    inMemory = false,
     timeoutMs = 10 * 60 * 1000,
   }: {
     initGenesisFromAncestry?: boolean;
@@ -22,6 +23,7 @@ export function runPicofuzzTest(
     highMemory?: boolean;
     flavour?: "tiny" | "full";
     memory?: string;
+    inMemory?: boolean;
     timeoutMs?: number;
   } = {},
 ) {
@@ -60,6 +62,7 @@ export function runPicofuzzTest(
           initGenesisFromAncestry,
           highMemory,
           memory,
+          inMemory,
           // typeberry config uses the American spelling; picofuzz CLI the British one.
           flavor: flavour,
         },

--- a/tests/picofuzz/conformance.test.ts
+++ b/tests/picofuzz/conformance.test.ts
@@ -9,4 +9,10 @@ runPicofuzzTest("conformance", EXAMPLES_DIR, {
   noLogs: true,
   ignore: [],
   highMemory: true,
+  // Run with a pure in-memory state db. Conformance re-initializes genesis state
+  // on every vector, which is pathologically slow on the on-disk fuzz db (the
+  // genesis reset re-opens/wipes the keyspace each time) — the on-disk fjall
+  // backend pushed this suite past its timeout. State roots don't depend on the
+  // storage backend, so in-memory keeps conformance correct and fast.
+  inMemory: true,
 });


### PR DESCRIPTION
## Problem

`Picofuzz Test (conformance)` has failed on **every** `main` run since ~2026-06-08 (green through `2026-06-08 18:54Z`, red every run since). It's a **timeout**, not a conformance divergence — picofuzz processes ~1300/1528 vectors with zero divergences, then the node watchdog (`timeout - 30s`) kills typeberry mid-`ImportBlock` and picofuzz exits 1 with a cryptic `Connection closed (socket.ts:67)`.

## Root cause (upstream)

The fuzz-target inherits `database_base_path: "./database"` from the default config, so it runs on an **on-disk** state db. typeberry **PR #1002 "Fjall hybrid db"** flipped that backend's default from LMDB to `fjall-hybrid`, and fjall is **~6.6× slower** on the conformance workload, which re-initializes genesis state on every vector (each reset re-opens/wipes the keyspace). Measured on the same 1528-vector corpus:

| build | States DB | result |
|---|---|---|
| `7cde74e` (parent of #1002) | `hybrid` (LMDB) | ✅ 1528/1528 in ~100s |
| `7d1719f` (#1002) … `0.9.0` | `fjall-hybrid` | ❌ 1314/1528 in >570s, killed |

Other tiny matrix jobs only slowed 1.2–1.5× (far fewer genesis resets), so only conformance tips over.

## Fix

Conformance validates **state-transition correctness**, and state roots are independent of the storage backend — so run it on a **pure in-memory** db. Adds an `inMemory` option to `runPicofuzzTest` / `typeberry()` that appends `--config=default --config=.database_base_path="undefined"` (the node maps an empty/`"undefined"` path to its in-memory backend). Only the conformance suite opts in; all other jobs are byte-identical to before.

This also fits the workload: conformance does short per-vector reset sessions, which the on-disk fuzz db is worst at and needs least (the disk store exists to bound heap during *long* soak runs).

## Trade-off

Conformance no longer exercises the on-disk fuzz db, so it's **no longer a fjall/LMDB perf canary**. That signal should move to a dedicated benchmark job (the other tiny jobs still run on-disk and retain weak coverage). The real fjall slowdown still wants an upstream fix in typeberry.

## Verification

- Local: `tsc --noEmit` ✅, `biome ci` ✅.
- End-to-end: this PR's `pull_request` trigger runs the conformance job — expect `🗄️ States DB: in-memory.` in the log and a ~100s pass instead of the >9-min timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)