### PR TITLE
Bump Docker Imports Full timeouts so the job can finish

### DIFF
--- a/.github/workflows/docker-imports-full.yml
+++ b/.github/workflows/docker-imports-full.yml
@@ -23,8 +23,10 @@ jobs:
     name: Docker Imports Full Chain Test
     # Imports the full 100k-block chain (~hours). Needs a dedicated beefier
     # 'non-perf' machine; on the shared runner this will not finish in time.
+    # Cap sits ~30 min above the test's own 360-min timeout so the test
+    # self-aborts and reaps its container before GitHub hard-kills the job.
     runs-on: [self-hosted, non-perf]
-    timeout-minutes: 240
+    timeout-minutes: 390
     steps:
       - uses: actions/checkout@v6
 

--- a/tests/docker-imports-full.test.ts
+++ b/tests/docker-imports-full.test.ts
@@ -3,9 +3,11 @@ import { CI_LABEL, killContainer, registerContainer, TYPEBERRY_IMAGE, uniqueCont
 import { ExternalProcess } from "./external-process.js";
 
 // Full import wall-clock depends heavily on the runner: ~70 min on a fast idle
-// box, far longer on a shared one. Sized for the dedicated non-perf machine,
-// under the workflow's 240-min job cap.
-const TEST_TIMEOUT = 210 * 60 * 1_000;
+// box, far longer on a shared/contended one. A scheduled run in 2026-06 reached
+// only ~block 83k/100k within 210 min (≈250 min projected for the full chain),
+// so this is sized well above that. Kept under the workflow's 390-min job cap so
+// the test self-aborts and reaps its container before GitHub hard-kills the job.
+const TEST_TIMEOUT = 360 * 60 * 1_000;
 
 // The dump holds blocks for time slots 0..100051; typeberry logs the slot of
 // the best block, so reaching the last block prints `Best: #100051`


### PR DESCRIPTION
## Problem

The scheduled **Docker Imports Full** job has been failing every day with:

```
✖ 'test timed out after 12600000ms'   # = 210 min
```

At the 210-min mark the import had only reached **block #83085 / 100051 (~83%)**, with steady block-by-block progress (~6.6 blocks/s) and no hang. So the job isn't stuck — it just needs more wall-clock than the current limit allows (≈250 min projected for the full chain on this runner).

## Root cause

The job has **two layered timeouts**, and the one actually firing was the *test-level* one, not the job cap:

| Layer | Value | Notes |
|---|---|---|
| `TEST_TIMEOUT` in `docker-imports-full.test.ts` | 210 min | drives both the `node:test` `describe` timeout **and** `.terminateAfter()` (the process kill) |
| workflow `timeout-minutes` | 240 min | GitHub job cap |

Because the 210-min test timeout fires first, bumping **only** `timeout-minutes` would have had **zero effect**. Both must move together.

## Fix

- `TEST_TIMEOUT`: **210 → 360 min** (~40% headroom over the ~250-min projection, for shared-runner load variance)
- workflow `timeout-minutes`: **240 → 390 min** (keeps the ~30-min headroom so the test self-aborts and reaps its container before GitHub hard-kills the job)

Comments in both files updated to record the reasoning.

The passing `picofuzz-full` job (same 210/240 design, but green — finishes in ~3h17m) is intentionally **left untouched**.

## Note (not addressed here)

This is a band-aid: ~250 min vs. the comment's "~70 min on a fast idle box" means the job is running ~3.6× slower than its design target — i.e. it's likely not landing on the dedicated beefy `non-perf` machine, or that host is contended. Extending this job to 6.5h on the single shared self-hosted runner also raises queue pressure on the other daily jobs. The durable fix is runner placement, not a wider window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)