### PR TITLE
Fix pr-benchmark disk space exhaustion

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -107,6 +107,15 @@ jobs:
           echo "Found workflow run ID: $WORKFLOW_RUN_ID"
           echo "workflow_run_id=$WORKFLOW_RUN_ID" >> $GITHUB_OUTPUT
 
+      - name: Free disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h .
+          docker image prune -f
+          rm -rf ./docker-image
+          echo "Disk after cleanup:"
+          df -h .
+
       - name: Download docker image artifact
         uses: actions/download-artifact@v8
         with:
@@ -118,8 +127,9 @@ jobs:
 
       - name: Load docker image
         run: |
-          gunzip ./docker-image/typeberry-image.tar.gz
-          docker load -i ./docker-image/typeberry-image.tar
+          # Stream directly into docker load to avoid writing the uncompressed tar to disk.
+          zcat ./docker-image/typeberry-image.tar.gz | docker load
+          rm -rf ./docker-image
           # Tag as the image the tests resolve via TYPEBERRY_IMAGE (default).
           IMAGE_ID=$(docker images --format "{{.ID}}" typeberry | head -n 1)
           if [ -z "$IMAGE_ID" ]; then


### PR DESCRIPTION
## Summary
- The [pr-benchmark job](https://github.com/FluffyLabs/typeberry-testing/actions/runs/28384386368) failed because the self-hosted runner ran out of disk space (15 MB free) while loading the docker image
- Stream `gunzip` directly into `docker load` (`zcat | docker load`) to avoid writing the intermediate uncompressed tar — roughly halves peak disk usage
- Add a cleanup step before download to prune dangling docker images and stale artifacts
- Remove the downloaded artifact immediately after loading to free space for the benchmark step

## Test plan
- [ ] Re-run the benchmark workflow to confirm it no longer fails with disk space errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)